### PR TITLE
Remove AltText module and fix container names

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 COMPOSE_FILE=docker-compose.yml
 COMPOSE_PROJECT_NAME=tul_omekadev
-DOCKER_IMAGE_VERSION=0.3.3
+DOCKER_IMAGE_VERSION=0.3.4
 IMAGE="tulibraries/tul_omeka-s"
 PROJECT_NAME=tul_omeka-s
 MAIL_SERVER_NAME="gmail.com"

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,6 @@ MAIL_SERVER ?= "smtp.gmail.com"
 MAIL_ADDRESS ?= "omeka@example.com"
 MAIL_PASSWORD ?= replace_me
 
-.PHONEY: init-app
-
 DEFAULT_RUN_ARGS ?= -e "EXECJS_RUNTIME=Disabled" \
     -e "K8=yes" \
     -e "OMEKA_DB_HOST=$(OMEKA_DB_HOST)" \

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ MAIL_SERVER ?= "smtp.gmail.com"
 MAIL_ADDRESS ?= "omeka@example.com"
 MAIL_PASSWORD ?= replace_me
 
+.PHONEY: init-app
+
 DEFAULT_RUN_ARGS ?= -e "EXECJS_RUNTIME=Disabled" \
     -e "K8=yes" \
     -e "OMEKA_DB_HOST=$(OMEKA_DB_HOST)" \
@@ -71,9 +73,15 @@ build_dev:
 pull_db:
 	@docker pull bitnami/mariadb:latest
 
-up: run_db run_app
+up: run_db init-app run_app
 
-run_app:
+init-app:
+	@docker run --name=$(PROJECT_NAME) \
+ 		--entrypoint=/bin/sh \
+		$(DEFAULT_RUN_ARGS) \
+		$(HARBOR)/$(IMAGE):$(VERSION) -c '/tmp/install-plugins.sh'
+
+run: init-app
 	@docker run --name=$(PROJECT_NAME) -d -p 127.0.0.1:80:80/tcp \
 		$(DEFAULT_RUN_ARGS) \
 		$(HARBOR)/$(IMAGE):$(VERSION)
@@ -85,7 +93,7 @@ run_dev:
 		$(IMAGE):dev sleep infinity
 
 run_db:
-	@docker run --name=omeka-db -d -p 127.0.0.1:3306:3306 \
+	@docker run --name=$(PROJECT_NAME)-db -d -p 127.0.0.1:3306:3306 \
 	  -e MARIADB_ROOT_PASSWORD=omeka \
     -e MARIADB_DATABASE=omeka \
     -e MARIADB_USER=omeka \
@@ -103,7 +111,7 @@ shell_dev:
 	@docker exec -u root -it $(PROJECT_NAME)-dev bash -l
 
 shell_db:
-	@docker exec -u root -it omeka-db bash -l
+	@docker exec -u root -it $(PROJECT_NAME)-db bash -l
 
 stop_dev:
 	@docker stop $(PROJECT_NAME)-dev
@@ -116,7 +124,7 @@ start_app:
 	@docker start $(PROJECT_NAME)
 
 start_db:
-	@docker start omeka-db
+	@docker start $(PROJECT_NAME)-db
 
 stop: stop_app stop_db
 
@@ -124,7 +132,7 @@ stop_app:
 	@docker stop $(PROJECT_NAME)
 
 stop_db:
-	@docker stop omeka-db
+	@docker stop $(PROJECT_NAME)-db
 
 reload: stop_app run_app
 
@@ -134,8 +142,8 @@ down_app:
 	@docker stop $(PROJECT_NAME)
 
 down_db:
-	@docker stop omeka-db
-	@docker rm omeka-db
+	@docker stop $(PROJECT_NAME)-db
+	@docker rm $(PROJECT_NAME)-db
 
 lint:
 	@if [ $(CI) == false ]; \

--- a/files/local/install-plugins.sh
+++ b/files/local/install-plugins.sh
@@ -2,23 +2,25 @@
 
 cd /tmp
 
+# Remove unused Directories
+if [ -d "/var/www/html/modules/AltText" ]; then
+  rm -rf /var/www/html/modules/AltText
+fi
+
 # Install Modules
-wget --no-verbose "https://github.com/omeka-s-modules/Mapping/releases/download/v1.4.1/Mapping-1.4.1.zip" && unzip Mapping-1.4.1.zip -d /var/www/html/modules/ 
-wget --no-verbose "https://github.com/Daniel-KM/Omeka-S-module-OaiPmhRepository/releases/download/3.3.5.4/OaiPmhRepository-3.3.5.4.zip" && unzip OaiPmhRepository-3.3.5.4.zip -d /var/www/html/modules/ 
-wget --no-verbose "https://github.com/Daniel-KM/Omeka-S-module-ImageServer/releases/download/3.6.7.3/ImageServer-3.6.7.3.zip" && unzip ImageServer-3.6.7.3.zip -d /var/www/html/modules/ 
-wget --no-verbose "https://github.com/Daniel-KM/Omeka-S-module-IiifServer/releases/download/3.6.5.3/IiifServer-3.6.5.3.zip" && unzip IiifServer-3.6.5.3.zip -d /var/www/html/modules/ 
-wget --no-verbose "https://github.com/omeka-s-modules/CSVImport/releases/download/v2.2.1/CSVImport-2.2.1.zip" && unzip CSVImport-2.2.1.zip -d /var/www/html/modules/ 
-wget --no-verbose "https://github.com/Daniel-KM/Omeka-S-module-BulkEdit/releases/download/3.3.12.4/BulkEdit-3.3.12.4.zip" && unzip BulkEdit-3.3.12.4.zip -d /var/www/html/modules/ 
-wget --no-verbose "https://github.com/zerocrates/AltText/releases/download/v1.2.1/AltText-1.2.1.zip" && unzip AltText-1.2.1.zip -d /var/www/html/modules/ 
-wget --no-verbose "https://github.com/omeka-s-modules/CSSEditor/releases/download/v1.3.0/CSSEditor-1.3.0.zip" && unzip CSSEditor-1.3.0.zip -d /var/www/html/modules/ 
+wget --no-verbose "https://github.com/omeka-s-modules/Mapping/releases/download/v1.4.1/Mapping-1.4.1.zip" && unzip -o Mapping-1.4.1.zip -d /var/www/html/modules/ && rm Mapping-1.4.1.zip 
+wget --no-verbose "https://github.com/Daniel-KM/Omeka-S-module-OaiPmhRepository/releases/download/3.3.5.4/OaiPmhRepository-3.3.5.4.zip" && unzip -o OaiPmhRepository-3.3.5.4.zip -d /var/www/html/modules/ && unzip -o OaiPmhRepository-3.3.5.4.zip 
+wget --no-verbose "https://github.com/Daniel-KM/Omeka-S-module-ImageServer/releases/download/3.6.7.3/ImageServer-3.6.7.3.zip" && unzip -o ImageServer-3.6.7.3.zip -d /var/www/html/modules/ && rm ImageServer-3.6.7.3.zip 
+wget --no-verbose "https://github.com/Daniel-KM/Omeka-S-module-IiifServer/releases/download/3.6.5.3/IiifServer-3.6.5.3.zip" && unzip -o IiifServer-3.6.5.3.zip -d /var/www/html/modules/ && rm IiifServer-3.6.5.3.zip 
+wget --no-verbose "https://github.com/omeka-s-modules/CSVImport/releases/download/v2.2.1/CSVImport-2.2.1.zip" && unzip -o CSVImport-2.2.1.zip -d /var/www/html/modules/ && rm CSVImport-2.2.1.zip 
+wget --no-verbose "https://github.com/Daniel-KM/Omeka-S-module-BulkEdit/releases/download/3.3.12.4/BulkEdit-3.3.12.4.zip" && unzip -o BulkEdit-3.3.12.4.zip -d /var/www/html/modules/ && rm BulkEdit-3.3.12.4.zip 
+wget --no-verbose "https://github.com/omeka-s-modules/CSSEditor/releases/download/v1.3.0/CSSEditor-1.3.0.zip" && unzip -o CSSEditor-1.3.0.zip -d /var/www/html/modules/ && rm CSSEditor-1.3.0.zip 
 
 # Install Themes
-wget --no-verbose "https://github.com/omeka-s-themes/default/releases/download/v1.6.1/theme-default-v1.6.1.zip" && unzip theme-default-v1.6.1.zip -d /var/www/html/themes/
-wget --no-verbose "https://github.com/omeka-s-themes/papers/releases/download/v1.3.1/theme-papers-v1.3.1.zip" && unzip theme-papers-v1.3.1.zip -d /var/www/html/themes/
-wget --no-verbose "https://github.com/omeka-s-themes/centerrow/releases/download/v1.6.0/theme-centerrow-v1.6.0.zip" && unzip theme-centerrow-v1.6.0.zip -d /var/www/html/themes/
-wget --no-verbose "https://github.com/omeka-s-themes/cozy/releases/download/v1.5.1/theme-cozy-v1.5.1.zip" && unzip theme-cozy-v1.5.1.zip -d /var/www/html/themes/
-wget --no-verbose "https://github.com/omeka-s-themes/foundation-s/releases/download/v1.1.0/theme-foundation-s-v1.1.0.zip" && unzip theme-foundation-s-v1.1.0.zip -d /var/www/html/themes/
-wget --no-verbose "https://github.com/omeka-s-themes/thanksroy/releases/download/v1.0.0/theme-thanksroy-v1.0.0.zip" && unzip theme-thanksroy-v1.0.0.zip -d /var/www/html/themes/
-wget --no-verbose "https://github.com/omeka-s-themes/thedaily/releases/download/v1.6.1/theme-thedaily-v1.6.1.zip" && unzip theme-thedaily-v1.6.1.zip -d /var/www/html/themes/
-
-rm *.zip
+wget --no-verbose "https://github.com/omeka-s-themes/default/releases/download/v1.6.1/theme-default-v1.6.1.zip" && unzip -o theme-default-v1.6.1.zip -d /var/www/html/themes/ && rm theme-default-v1.6.1.zip 
+wget --no-verbose "https://github.com/omeka-s-themes/papers/releases/download/v1.3.1/theme-papers-v1.3.1.zip" && unzip -o theme-papers-v1.3.1.zip -d /var/www/html/themes/ && rm theme-papers-v1.3.1.zip 
+wget --no-verbose "https://github.com/omeka-s-themes/centerrow/releases/download/v1.6.0/theme-centerrow-v1.6.0.zip" && unzip -o theme-centerrow-v1.6.0.zip -d /var/www/html/themes/&& rm theme-centerrow-v1.6.0.zip 
+wget --no-verbose "https://github.com/omeka-s-themes/cozy/releases/download/v1.5.1/theme-cozy-v1.5.1.zip" && unzip -o theme-cozy-v1.5.1.zip -d /var/www/html/themes/ && rm theme-cozy-v1.5.1.zip 
+wget --no-verbose "https://github.com/omeka-s-themes/foundation-s/releases/download/v1.1.0/theme-foundation-s-v1.1.0.zip" && unzip -o theme-foundation-s-v1.1.0.zip -d /var/www/html/themes/ && rm theme-foundation-s-v1.1.0.zip 
+wget --no-verbose "https://github.com/omeka-s-themes/thanksroy/releases/download/v1.0.0/theme-thanksroy-v1.0.0.zip" && unzip -o theme-thanksroy-v1.0.0.zip -d /var/www/html/themes/ && rm theme-thanksroy-v1.0.0.zip 
+wget --no-verbose "https://github.com/omeka-s-themes/thedaily/releases/download/v1.6.1/theme-thedaily-v1.6.1.zip" && unzip -o theme-thedaily-v1.6.1.zip -d /var/www/html/themes/ && rm theme-thedaily-v1.6.1.zip 


### PR DESCRIPTION
- Remove AltText module instead of upgradeing. Module is not
needed in latest versions of Omeka-S
- Use consistent container names - May fix some inter-
container communication problems.