### PR TITLE
Ex 112 update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 /modules
 /themes
 /volume
+/data

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ showenv:
 
 build: pull_db build_app
 
-build_app:
+build-app:
 	@docker build \
 		--tag $(HARBOR)/$(IMAGE):$(VERSION) \
 		--tag $(HARBOR)/$(IMAGE):latest \
@@ -68,7 +68,7 @@ build_dev:
 		--progress=$(BUILD_PROGRESS) \
 		--no-cache .
 
-pull_db:
+pull-db:
 	@docker pull bitnami/mariadb:latest
 
 up: run_db init-app run_app
@@ -90,7 +90,7 @@ run_dev:
 		--mount type=bind,source=$(PWD),target=/build \
 		$(IMAGE):dev sleep infinity
 
-run_db:
+run-db:
 	@docker run --name=$(PROJECT_NAME)-db -d -p 127.0.0.1:3306:3306 \
 	  -e MARIADB_ROOT_PASSWORD=omeka \
     -e MARIADB_DATABASE=omeka \

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ showenv:
 
 build: pull_db build_app
 
-build-app:
+build_app:
 	@docker build \
 		--tag $(HARBOR)/$(IMAGE):$(VERSION) \
 		--tag $(HARBOR)/$(IMAGE):latest \
@@ -68,7 +68,7 @@ build_dev:
 		--progress=$(BUILD_PROGRESS) \
 		--no-cache .
 
-pull-db:
+pull_db:
 	@docker pull bitnami/mariadb:latest
 
 up: run_db init-app run_app
@@ -90,7 +90,7 @@ run_dev:
 		--mount type=bind,source=$(PWD),target=/build \
 		$(IMAGE):dev sleep infinity
 
-run-db:
+run_db:
 	@docker run --name=$(PROJECT_NAME)-db -d -p 127.0.0.1:3306:3306 \
 	  -e MARIADB_ROOT_PASSWORD=omeka \
     -e MARIADB_DATABASE=omeka \

--- a/README.md
+++ b/README.md
@@ -1,47 +1,30 @@
-# tul_omeka-s
+# Temple University Libary Exhibits (tul_omeka-s)
 
-*DRAFT*
+## Deployment
+This application is deployed with a Helm Chart that is located in Temple Libraries private Gitlab repository.  Access to the repository and the QA application require the user to be logged in to the Temple VPN.
 
-# Mounted Volumes for Persistence
+The QA site can be found at https://exhibits-qa.k8s.temple.edu.
 
-- Rancher Workload
-- Edit workload
-- Volumes >> Add Volume
-	- Add a new persistent volume (claim)
-	- Name: Name the volume. e.g. "tul-omeka-prototype-volume"
-		- Note: Use alphanumerics separated by hyphens. Underscores not accepted
-	- Add a description (Optional)
-	- Source: Select "Use a Storage Class to provision a new persistent volume"
-	- Storage Class: "Use the default class"
-	- Request Storage: e.g. 2 GiB
-	- Access Mode: " Single Node Read-Write"
-	- >> Define
-		- Volume name: As defined above
-		- Mount Point: /var/www/html/files
-		- Subpath in Volume: files
-	- >> Add Mount (if needed)
-		- Volume name: As defined above
-		- Mount Point:/var/www/html/modules
-		- Subpath in Volume: modules
-	- >> Add Mount (if needed)
-		- Volume name: As defined above
-		- Mount Point: /var/www/html/themes
-		- Subpath in Volume: themes
-	- >> Save (bottom of form)
-- Workload will update, Status: "updating workload"
-- Rancher Workload Dashboard
-- Scroll to tul-omeka-s workload
-- Click on menu (Three dots on right)
-- Verify mounted volumes `ls`
-	- Note mounted volumes are owned by `root`
-- Change owner and group of mounted volumes
+## Getting Started
+We defined a Makefile with many useful commands for local development. These commands replicate the process used to deploy in the Gitlab pipeline.
 
-```
-$ chown -R www-data:www-data files modules themes
-$ exit
-```
+There are also some directories that you will need to create locally.  Directories that should not be committed to GitHub are included in the .gitignore file.
+- `mkdir -p data/db`
+- `mkdir -p files/apache2`
+- `mkdir -p files/local`
+- `mkdir -p volume/modules`
+- `mkdir -p volume/themes`
+- `mkdir -p volume/files`
 
-# Install Extensions
+To start up a local instance, run the following make commands. You will need to be logged into the Temple VPN in order to access the Harbor images.   
+- `make build-app`
+- `make pull-db`
+- `make run-db`
+- `make run`
+
+Once the application is running, it can be accessed at http://localhost:80. You will need to create a user in order to enter the application.
+
+## Install Extensions
 
 1. In browser, visit the Rancher Workload Dashboard
 2. Scroll to tul-omeka-s workload
@@ -65,7 +48,7 @@ As an administrative user on the Omeka Web Application, modules are activated an
 from the Admin menu on the left side of the administration dashboard.  Themes are selected
 and configured from the Sites menu item on the left side of the administrative dashboard.
 
-## Module List
+### Module List
 
 - https://github.com/omeka-s-modules/Mapping/releases/download/v1.4.1/Mapping-1.4.1.zip"
 - https://github.com/Daniel-KM/Omeka-S-module-OaiPmhRepository/releases/download/3.3.5.4/OaiPmhRepository-3.3.5.4.zip"
@@ -76,7 +59,7 @@ and configured from the Sites menu item on the left side of the administrative d
 - https://github.com/zerocrates/AltText/releases/download/v1.2.1/AltText-1.2.1.zip
 - https://github.com/omeka-s-modules/CSSEditor/releases/download/v1.3.0/CSSEditor-1.3.0.zip
 
-## Themes List
+### Themes List
 
 - https://github.com/omeka-s-themes/default/releases/download/v1.6.1/theme-default-v1.6.1.zip
 - https://github.com/omeka-s-themes/papers/releases/download/v1.3.1/theme-papers-v1.3.1.zip
@@ -85,3 +68,6 @@ and configured from the Sites menu item on the left side of the administrative d
 - https://github.com/omeka-s-themes/foundation-s/releases/download/v1.1.0/theme-foundation-s-v1.1.0.zip
 - https://github.com/omeka-s-themes/thanksroy/releases/download/v1.0.0/theme-thanksroy-v1.0.0.zip
 - https://github.com/omeka-s-themes/thedaily/releases/download/v1.6.1/theme-thedaily-v1.6.1.zip
+
+
+

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ There are also some directories that you will need to create locally.  Directori
 
 To start up a local instance, run the following make commands. You will need to be logged into the Temple VPN in order to access the Harbor images.   
 - `make build`
-- `make run-db`
-- `make run`
+- `make up`
 
 Once the application is running, it can be accessed at http://localhost:80. You will need to create a user in order to enter the application.
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ There are also some directories that you will need to create locally.  Directori
 - `mkdir -p volume/files`
 
 To start up a local instance, run the following make commands. You will need to be logged into the Temple VPN in order to access the Harbor images.   
-- `make build-app`
-- `make pull-db`
+- `make build`
 - `make run-db`
 - `make run`
 


### PR DESCRIPTION
- With the rancher UI updates, and the move to deploying with helm charts, the persistent storage directions are no longer accurate so they were removed.
- Adds information related to deployments and setting up a local instance.
- Adds files that should not be committed to the .gitignore file
- When setting this up locally, the modules and themes were installed in the volume directory.  This removes the top level empty directories.
