### PR TITLE
Make omeka container read-only

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -56,6 +56,7 @@ RUN apk add -U --no-cache \
 &&  rm -rf /var/www/html/ \
 &&  mv /var/www/omeka-s/ /var/www/html/ \
 &&  mkdir -p /var/www/html/config/ && mkdir -p /var/www/html/files/ && mkdir -p /var/www/html/modules/ && mkdir -p /var/www/html/themes/  \
+&&  mkdir -p /var/log/ \
 &&  mkdir -p /etc/ImageMagick-6/ \
 &&  cp imagemagick-policy.xml /etc/ImageMagick-6/policy.xml \
 &&  cp .htaccess /var/www/html/.htaccess \

--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 COMPOSE_FILE=docker-compose.yml
 COMPOSE_PROJECT_NAME=tul_omekadev
-DOCKER_IMAGE_VERSION=0.3.4
+DOCKER_IMAGE_VERSION=0.3.5
 IMAGE="tulibraries/tul_omeka-s"
 PROJECT_NAME=tul_omeka-s
 MAIL_SERVER_NAME="gmail.com"

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /themes
 /volume
 /data
+/tmpfs

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,13 @@ DEFAULT_RUN_ARGS ?= -e "EXECJS_RUNTIME=Disabled" \
     -e "MAIL_SERVER=$(MAIL_SERVER)" \
     -e "MAIL_ADDRESS=$(MAIL_ADDRESS)" \
     -e "MAIL_PASSWORD=$(MAIL_PASSWORD)" \
-		--mount type=bind,source="$(shell pwd)/volume/files",target=/var/www/html/files \
-		--mount type=bind,source="$(shell pwd)/volume/modules",target=/var/www/html/modules \
-		--mount type=bind,source="$(shell pwd)/volume/themes",target=/var/www/html/themes \
-		--mount type=bind,source="$(shell pwd)/volume/log",target=/var/log/apache2 \
+    --mount type=bind,source="$(shell pwd)/volume/files",target=/var/www/html/files \
+    --mount type=bind,source="$(shell pwd)/volume/modules",target=/var/www/html/modules \
+    --mount type=bind,source="$(shell pwd)/volume/themes",target=/var/www/html/themes \
+    --mount type=bind,source="$(shell pwd)/volume/log",target=/var/log/apache2 \
     --read-only \
-		--mount type=bind,source="$(shell pwd)/tmpfs/run/apache2",target=/run/apache2 \
-		--mount type=bind,source="$(shell pwd)/tmpfs/tmp",target=/tmp \
+    --mount type=bind,source="$(shell pwd)/tmpfs/run/apache2",target=/run/apache2 \
+    --mount type=bind,source="$(shell pwd)/tmpfs/tmp",target=/tmp \
     --rm -it
 
 build: pull-db 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ DEFAULT_RUN_ARGS ?= -e "EXECJS_RUNTIME=Disabled" \
 		--mount type=bind,source="$(shell pwd)/volume/files",target=/var/www/html/files \
 		--mount type=bind,source="$(shell pwd)/volume/modules",target=/var/www/html/modules \
 		--mount type=bind,source="$(shell pwd)/volume/themes",target=/var/www/html/themes \
+		--mount type=bind,source="$(shell pwd)/volume/log",target=/var/log/apache2 \
+    --read-only \
+		--mount type=bind,source="$(shell pwd)/tmpfs/run/apache2",target=/run/apache2 \
+		--mount type=bind,source="$(shell pwd)/tmpfs/tmp",target=/tmp \
     --rm -it
 
 build: pull-db 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ There are also some directories that you will need to create locally.  Directori
 - `mkdir -p volume/modules`
 - `mkdir -p volume/themes`
 - `mkdir -p volume/files`
+- `mkdir -p volume/log`
+- `mkdir -p tmpfs/tmp`
+- `mkdir -p tmpfs/run/apache2`
 
 To start up a local instance, run the following make commands. You will need to be logged into the Temple VPN in order to access the Harbor images.   
 - `make build`


### PR DESCRIPTION
- Run omeka container locally as read-only
- Mounts /var/log/apache2 on existing mountable storage volume
- Creates temporary mountable volumes for /tmp and  /run/apache2