### PR TITLE
EX-138 Use CSRF policies specified for CKEditor

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 COMPOSE_FILE=docker-compose.yml
 COMPOSE_PROJECT_NAME=tul_omekadev
-DOCKER_IMAGE_VERSION=0.4.9
+DOCKER_IMAGE_VERSION=0.4.10
 IMAGE="tulibraries/tul_omeka-s"
 PROJECT_NAME=tul_omeka-s
 MAIL_SERVER_NAME="gmail.com"

--- a/files/apache2/httpd.conf
+++ b/files/apache2/httpd.conf
@@ -388,9 +388,16 @@ LogLevel warn
     # 'Proxy' request header is undefined by the IETF, not listed by IANA
     #
     RequestHeader unset Proxy early
-    Header set Content-Security-Policy "default-src 'self' code.jquery.com fonts.googleapis.com fonts.gstatic.com; \
-      style-src 'self' fonts.googleapis.com *.tile.openstreetmap.org; \
-      img-src 'self' *.tile.openstreetmap.org; \
+    #
+    # Set Content Security Policy
+    #
+    Header set Content-Security-Policy " \
+      default-src 'none'; \
+      connect-src 'self'; \
+      script-src 'self' code.jquery.com; \
+      img-src * data:; \
+      style-src 'self' 'unsafe-inline' fonts.googleapis.com; \
+      frame-src *; \
       font-src 'self' fonts.googleapis.com fonts.gstatic.com;"
     Header set X-Content-Type-Options "NOSNIFF"
     Header set X-Frame-Options "DENY"


### PR DESCRIPTION
- Fixes blocking policy for CKEditor using content-security-policy in the CKEditor documentation