### PR TITLE
Update documentation, stay on current omeka version

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -1,6 +1,6 @@
 FROM harbor.k8s.temple.edu/library/httpd:2.4-alpine
 
-ARG OMEKA_VERSION=4.1.1
+ARG OMEKA_VERSION=4.0.4
 
 WORKDIR /build
 

--- a/Documentation/Node.js-CVE-2023-4771
+++ b/Documentation/Node.js-CVE-2023-4771
@@ -1,1 +1,0 @@
-Waiting for node.js to fix the vulnerability

--- a/Documentation/Node.js-CVE-2024-24815
+++ b/Documentation/Node.js-CVE-2024-24815
@@ -1,1 +1,0 @@
-Waiting for node.js to fix the vulnerability

--- a/Documentation/Node.js-CVE-2024-24816
+++ b/Documentation/Node.js-CVE-2024-24816
@@ -1,1 +1,0 @@
-Waiting for node.js to fix the vulnerability

--- a/Documentation/Node.js-CVE-2025-26791
+++ b/Documentation/Node.js-CVE-2025-26791
@@ -1,0 +1,1 @@
+Waiting for node.js to fix the vulnerability

--- a/Documentation/essential_packages.txt
+++ b/Documentation/essential_packages.txt
@@ -1,1 +1,1 @@
-ckeditor4
+dompurify

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ git submodule update --recursive --force
 
 cd ./omeka-s
 echo "APPLY OMEKA SECURITY PATCHES"
-npm audit fix --omit dev || true
+npm audit fix --omit dev
 npm install
 npm install ckeditor4@4.25.0
 npx gulp init


### PR DESCRIPTION
The latest omeka version introduces a critical security vulnerability with no fix, so this reverts that change and updates documentation for a minor vulnerability that needs to be addressed.  Also cleans up documentation for issues that have been resolved.